### PR TITLE
fix(SCRUM-536): Remove explicit setting of date to midnight during ho…

### DIFF
--- a/src/user-preferences/services/hour-preferences.service.ts
+++ b/src/user-preferences/services/hour-preferences.service.ts
@@ -23,12 +23,10 @@ export class HourPreferencesService {
       for (const hourPreference of validHourPreferences) {
         let date: Date | undefined;
 
-        //? Check if the date is a valid date string, puts the date at 00:00:00
         if (hourPreference.date) {
           const parsed = new Date(hourPreference.date);
           if (!Number.isNaN(parsed.getTime())) {
             date = parsed;
-            date.setHours(0, 0, 0, 0);
           }
         }
         await tx.userHourPreferences.create({

--- a/src/user-preferences/services/hour-preferences.service.ts
+++ b/src/user-preferences/services/hour-preferences.service.ts
@@ -24,9 +24,14 @@ export class HourPreferencesService {
         let date: Date | undefined;
 
         if (hourPreference.date) {
+          //? Check if the date is a valid date string,
           const parsed = new Date(hourPreference.date);
           if (!Number.isNaN(parsed.getTime())) {
             date = parsed;
+            //? puts the date at 00:00:00 if the preference is recurrent
+            if (hourPreference.type === UserHourPreferenceType.RECURRENT) {
+              date.setHours(0, 0, 0, 0);
+            }
           }
         }
         await tx.userHourPreferences.create({


### PR DESCRIPTION
il faut garder l'heure lors de la sélection d'une préférence ONE_TIME. Si la date est envoyée avec une heure à zéro (00:00:00), le backend risque de considérer la date du jour comme déjà expirée. L'inclusion de l'heure permet de garantir que les sélections effectuées aujourd'hui restent valides.

Avant : 

https://github.com/user-attachments/assets/43bc6a6c-6b42-4ac8-a9e6-970b77203e1b

Après : 

https://github.com/user-attachments/assets/1c67bd4e-911e-4831-9ff9-dbbff77e9d4c







